### PR TITLE
Update .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,8 @@ coverage:
   status:
     project: off
     patch:
-      only_pulls: true
+      default:
+        only_pulls: true
 
 # Only comment on PR if coverage changes
 # https://docs.codecov.io/docs/pull-request-comments


### PR DESCRIPTION
Codecov has multiple statuses. So we need to define the status context which is `default` for the default status.