### PR TITLE
Warn user if custom fig.path is ignored

### DIFF
--- a/tests/testthat/files/test-wflow_html/fig-path-all-chunks.Rmd
+++ b/tests/testthat/files/test-wflow_html/fig-path-all-chunks.Rmd
@@ -1,0 +1,23 @@
+---
+title: "Untitled"
+output: workflowr::wflow_html
+---
+
+In this example, a custom fig.path is set globally, which should result in a
+warning for each plot (3 total).
+
+```{r setup}
+knitr::opts_chunk$set(fig.path = "anything/")
+```
+
+```{r plot-one}
+plot(1:10)
+```
+
+```{r plot-two}
+plot(1:10)
+```
+
+```{r plot-three}
+plot(1:10)
+```

--- a/tests/testthat/files/test-wflow_html/fig-path-one-chunk.Rmd
+++ b/tests/testthat/files/test-wflow_html/fig-path-one-chunk.Rmd
@@ -1,0 +1,19 @@
+---
+title: "Untitled"
+output: workflowr::wflow_html
+---
+
+In this example, a custom fig.path is set for only one chunk, which should
+result in only one warning.
+
+```{r plot-one, fig.path="custom"}
+plot(1:10)
+```
+
+```{r plot-two}
+plot(1:10)
+```
+
+```{r plot-three}
+plot(1:10)
+```

--- a/tests/testthat/test-wflow_html.R
+++ b/tests/testthat/test-wflow_html.R
@@ -190,7 +190,6 @@ test_that("The default knit_root_dir for a workflowr project is the root directo
   expect_true(sum(stringr::str_detect(html_lines, tmp_dir)) == 1)
 })
 
-
 test_that("The default knit_root_dir for a workflowr project can be analysis/", {
 
   skip_on_cran()
@@ -281,6 +280,36 @@ test_that("github URL in _workflowr.yml overrides git remote", {
   expect_false(any(stringr::str_detect(html_lines,
                                        "https://github.com/testuser/testrepo")))
 })
+
+# Test plot_hook ---------------------------------------------------------------
+
+test_that("wflow_html sends warning if fig.path is set by user", {
+
+  skip_on_cran()
+
+  tmp_dir <- tempfile()
+  dir.create(tmp_dir)
+  tmp_dir <- workflowr:::absolute(tmp_dir)
+  on.exit(unlink(tmp_dir, recursive = TRUE))
+
+  # If set in only only one chunk, only one warning should be generated
+  rmd <- file.path(tmp_dir, "file.Rmd")
+  file.copy("files/test-wflow_html/fig-path-one-chunk.Rmd", rmd)
+  html <- render(rmd, quiet = TRUE)
+  expect_true(file.exists(html))
+  html_lines <- readLines(html)
+  expect_true(sum(stringr::str_detect(html_lines, "<code>fig.path</code>")) == 1)
+
+  # If set globally, a warning should be generated for each plot (in this case 3)
+  rmd2 <- file.path(tmp_dir, "file2.Rmd")
+  file.copy("files/test-wflow_html/fig-path-all-chunks.Rmd", rmd2)
+  html2 <- render(rmd2, quiet = TRUE)
+  expect_true(file.exists(html2))
+  html_lines2 <- readLines(html2)
+  expect_true(sum(stringr::str_detect(html_lines2, "<code>fig.path</code>")) == 3)
+
+})
+
 
 # Test add_bibliography --------------------------------------------------------
 

--- a/vignettes/wflow-01-getting-started.Rmd
+++ b/vignettes/wflow-01-getting-started.Rmd
@@ -181,7 +181,11 @@ website. The HTML files are built from the R Markdown files in
 are saved here. Each of these figures is saved according to the
 following pattern: `docs/figure/<insert Rmd filename>/<insert chunk
 name>-#.png`, where `#` corresponds to which of the plots the chunk
-generated (since one chunk can produce an arbitrary number of plots).
+generated (since one chunk can produce an arbitrary number of plots)^[Because of
+this requirement, you can't customize the knitr option `fig.path` (which
+controls where figure files are saved) in any R Markdown file that is part of a
+workflowr project. If you do set it, it will be ignored and workflowr will
+insert a warning into the HTML file to alert you.].
 
 The workflowr-specific configuration file is `_workflowr.yml`. It will apply the
 workflowr reproducibility checks consistently across all your R Markdown files.

--- a/vignettes/wflow-04-how-it-works.Rmd
+++ b/vignettes/wflow-04-how-it-works.Rmd
@@ -76,6 +76,12 @@ figures in `docs` corresponding to new or updated R Markdown files, and
 `analysis/figure/` is in the `.gitignore` file to prevent accidentally
 committing duplicate files.
 
+Because workflowr requires the figures to be saved to a specific location in
+order to function properly, it will override any custom setting of the knitr
+option `fig.path` (which controls where figure files are saved) and insert a
+warning into the HTML file to alert the user that their value for `fig.path` was
+ignored.
+
 ## Additional tools
 
 [RStudio, Inc.][] is a company that develops open source software for R users.


### PR DESCRIPTION
* Insert warning into HTML noting that custom fig.path was set
* Add footnote to "Getting started" vignette
* Add paragraph to vignette on workflowr implementation

Addresses #114. @lazappi please review.