### PR TITLE
add support for fig_path_ext option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .Ruserdata
 .Rapp.history
 .DS_Store
+.vscode
 inst/doc
 vignettes/*R
 vignettes/*html

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: false
 cache: packages
 latex: false
 
+# Temporarily use callr 2.0.4
+# https://github.com/r-lib/callr/commit/abd9fe8288acba17ab6a3a797e4ad146186ed3f9#diff-35ba4a2677442e210c23a00a5601aba3
+r_github_packages: r-lib/callr@abd9fe8288acba17ab6a3a797e4ad146186ed3f9
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ sudo: false
 cache: packages
 latex: false
 
-# Temporarily use callr 2.0.4
-# https://github.com/r-lib/callr/commit/abd9fe8288acba17ab6a3a797e4ad146186ed3f9#diff-35ba4a2677442e210c23a00a5601aba3
-r_github_packages: r-lib/callr@abd9fe8288acba17ab6a3a797e4ad146186ed3f9
-
 env:
   global:
     # Do not skip tests with skip_on_cran(). Adding this to be explicit for my

--- a/R/wflow_build.R
+++ b/R/wflow_build.R
@@ -248,7 +248,7 @@ wflow_build <- function(files = NULL, make = is.null(files),
     for (f in files_to_build) {
       message("Building ", f)
       # Remove figure files to prevent accumulating outdated files
-      path <- create_figure_path(basename(f))
+      path <- create_figure_path(f)
       figs_analysis <- file.path(p$analysis, path)
       unlink(figs_analysis, recursive = TRUE)
       figs_docs <- file.path(p$docs, path)

--- a/R/wflow_build.R
+++ b/R/wflow_build.R
@@ -248,9 +248,10 @@ wflow_build <- function(files = NULL, make = is.null(files),
     for (f in files_to_build) {
       message("Building ", f)
       # Remove figure files to prevent accumulating outdated files
-      figs_analysis <- file.path(p$analysis, "figure", basename(f))
+      path <- create_figure_path(basename(f))
+      figs_analysis <- file.path(p$analysis, path)
       unlink(figs_analysis, recursive = TRUE)
-      figs_docs <- file.path(p$docs, "figure", basename(f))
+      figs_docs <- file.path(p$docs, path)
       unlink(figs_docs, recursive = TRUE)
       if (local) {
         build_rmd(f, seed = seed, envir = .GlobalEnv)

--- a/R/wflow_html.R
+++ b/R/wflow_html.R
@@ -161,7 +161,8 @@ wflow_html <- function(...) {
     # the setting was ignored.
     options$fig.path.orig <- options$fig.path
 
-    options$fig.path <- file.path("figure", knitr::current_input())
+    input <- knitr::current_input()
+    options$fig.path <- create_figure_path(input)
     # Requires trailing slash
     options$fig.path <- paste0(options$fig.path, .Platform$file.sep)
     return(options)

--- a/R/wflow_options.R
+++ b/R/wflow_options.R
@@ -59,9 +59,9 @@ is_fig_path_ext <- function(input) {
 create_figure_path <- function(input) {
 
   if (is_fig_path_ext(input)){
-    res <- file.path("figure", tools::file_path_sans_ext(input))
+    res <- file.path("figure", basename(tools::file_path_sans_ext(input)))
   } else {
-    res <- file.path("figure", input)
+    res <- file.path("figure", basename(input))
   }
   res
 }

--- a/R/wflow_options.R
+++ b/R/wflow_options.R
@@ -7,13 +7,15 @@
 #  seed - random seed to set at beginning of each analysis
 #  github - URL to associated GitHub repository
 #  sessioninfo - Function to record session information
+#  fig_path_ext - figures directory with or without .Rmd
 wflow_options <- function(file) {
 
   # Default wflow options
   wflow_opts <- list(knit_root_dir = NULL,
                      seed = 12345,
                      github = get_host_from_remote(dirname(file)),
-                     sessioninfo = "sessionInfo()")
+                     sessioninfo = "sessionInfo()",
+                     fig_path_ext = FALSE)
 
   # Get options from a potential _workflowr.yml file
   wflow_root <- try(rprojroot::find_root(rprojroot::has_file("_workflowr.yml"),
@@ -35,4 +37,31 @@ wflow_options <- function(file) {
   }
 
   return(wflow_opts)
+}
+
+#' check the fig_path_ext option
+#'
+#' @param input the path to a RMarkdown file
+#'
+#' @keywords internal
+is_fig_path_ext <- function(input) {
+
+  wflow_opts <- wflow_options(input)
+
+  wflow_opts$fig_path_ext
+}
+
+#' create the path to the figure folder
+#'
+#' @param input the path to a RMarkdown file
+#'
+#' @keywords internal
+create_figure_path <- function(input) {
+
+  if (is_fig_path_ext(input)){
+    res <- file.path("figure", tools::file_path_sans_ext(input))
+  } else {
+    res <- file.path("figure", input)
+  }
+  res
 }

--- a/R/wflow_publish.R
+++ b/R/wflow_publish.R
@@ -234,7 +234,7 @@ wflow_publish <- function(
 
     # Have to loop on step2$built as an underlying git2r function requires a
     # length 1 character vector
-    figs_path <- vapply(basename(step2$built), create_figure_path, character(1))
+    figs_path <- vapply(step2$built, create_figure_path, character(1))
     dir_figure <- file.path(s2$docs, figs_path)
     site_libs <- file.path(s2$docs, "site_libs")
     docs_nojekyll <- file.path(s2$docs, ".nojekyll")

--- a/R/wflow_publish.R
+++ b/R/wflow_publish.R
@@ -231,7 +231,11 @@ wflow_publish <- function(
 
   # Step 3 only needs to be performed if files were built in step 2.
   if (length(step2$built) > 0) {
-    dir_figure <- file.path(s2$docs, "figure", basename(step2$built))
+
+    # Have to loop on step2$built as an underlying git2r function requires a
+    # length 1 character vector
+    figs_path <- vapply(basename(step2$built), create_figure_path, character(1))
+    dir_figure <- file.path(s2$docs, figs_path)
     site_libs <- file.path(s2$docs, "site_libs")
     docs_nojekyll <- file.path(s2$docs, ".nojekyll")
     files_to_commit <- c(step2$html, dir_figure, site_libs, docs_nojekyll)

--- a/R/wflow_remove.R
+++ b/R/wflow_remove.R
@@ -126,9 +126,9 @@ wflow_remove <- function(files,
     }
     # Any figure files in analysis directory?
     if (p$analysis == ".") {
-      dir_figs_analysis <- file.path("figure", basename(rmd))
+      dir_figs_analysis <- create_figure_path(rmd)
     } else {
-      dir_figs_analysis <- file.path(p$analysis, "figure", basename(rmd))
+      dir_figs_analysis <- file.path(p$analysis, create_figure_path(rmd))
     }
     figs_analysis <- list.files(path = dir_figs_analysis, full.names = TRUE)
     if (length(figs_analysis) > 0) {
@@ -137,9 +137,9 @@ wflow_remove <- function(files,
     }
     # Any figure files in docs directory?
     if (p$docs == ".") {
-      dir_figs_docs <- file.path("figure", basename(rmd))
+      dir_figs_docs <- create_figure_path(rmd)
     } else {
-      dir_figs_docs <- file.path(p$docs, "figure", basename(rmd))
+      dir_figs_docs <- file.path(p$docs, create_figure_path(rmd))
     }
     figs_docs <- list.files(path = dir_figs_docs, full.names = TRUE)
     if (length(figs_docs) > 0) {

--- a/R/wflow_remove.R
+++ b/R/wflow_remove.R
@@ -125,7 +125,7 @@ wflow_remove <- function(files,
       files_to_remove <- c(files_to_remove, html)
     }
     # Any figure files in analysis directory?
-    fig_path <- create_figure_path(basename(rmd))
+    fig_path <- create_figure_path(rmd)
     if (p$analysis == ".") {
       dir_figs_analysis <- fig_path
     } else {

--- a/R/wflow_remove.R
+++ b/R/wflow_remove.R
@@ -125,10 +125,11 @@ wflow_remove <- function(files,
       files_to_remove <- c(files_to_remove, html)
     }
     # Any figure files in analysis directory?
+    fig_path <- create_figure_path(basename(rmd))
     if (p$analysis == ".") {
-      dir_figs_analysis <- create_figure_path(rmd)
+      dir_figs_analysis <- fig_path
     } else {
-      dir_figs_analysis <- file.path(p$analysis, create_figure_path(rmd))
+      dir_figs_analysis <- file.path(p$analysis, fig_path)
     }
     figs_analysis <- list.files(path = dir_figs_analysis, full.names = TRUE)
     if (length(figs_analysis) > 0) {
@@ -137,9 +138,9 @@ wflow_remove <- function(files,
     }
     # Any figure files in docs directory?
     if (p$docs == ".") {
-      dir_figs_docs <- create_figure_path(rmd)
+      dir_figs_docs <- fig_path
     } else {
-      dir_figs_docs <- file.path(p$docs, create_figure_path(rmd))
+      dir_figs_docs <- file.path(p$docs, fig_path)
     }
     figs_docs <- list.files(path = dir_figs_docs, full.names = TRUE)
     if (length(figs_docs) > 0) {

--- a/R/wflow_site.R
+++ b/R/wflow_site.R
@@ -86,7 +86,7 @@ wflow_site <- function(input, encoding = getOption("encoding"), ...) {
         output_file <- file.path(output_dir, basename(output_file))
 
         # Move figures
-        fig_dir <- create_figure_path(basename(f))
+        fig_dir <- create_figure_path(f)
         fig_dir <- file.path(input, fig_dir)
 
         if (dir.exists(fig_dir)) {

--- a/R/wflow_site.R
+++ b/R/wflow_site.R
@@ -86,7 +86,9 @@ wflow_site <- function(input, encoding = getOption("encoding"), ...) {
         output_file <- file.path(output_dir, basename(output_file))
 
         # Move figures
-        fig_dir <- file.path(input, "figure", basename(f))
+        fig_dir <- create_figure_path(basename(f))
+        fig_dir <- file.path(input, fig_dir)
+
         if (dir.exists(fig_dir)) {
           fig_output_dir <- file.path(output_dir, "figure")
           dir.create(fig_output_dir, showWarnings = FALSE)

--- a/tests/testthat/test-build_rmd_external.R
+++ b/tests/testthat/test-build_rmd_external.R
@@ -72,6 +72,9 @@ test_that("An error stops execution, does not create file,
     build_rmd_external("error.Rmd", seed = 1, log_dir = l)),
                "There was an error")
   expect_false(file.exists("_site/error.html"))
+
+  skip("callr 3.0.0 doesn't write the error message to stderr")
+  # https://github.com/r-lib/callr/issues/80
   stderr_lines <- readLines(Sys.glob(file.path(l, "error.Rmd-*-err.txt")))
   expect_true(any(grepl("There was an error", stderr_lines)))
 })

--- a/tests/testthat/test-fig_path_ext.R
+++ b/tests/testthat/test-fig_path_ext.R
@@ -30,7 +30,7 @@ test_that("fig_path_ext has no effect when set to FALSE", {
   # Figure functions detect that the setting is FALSE
   expect_false(workflowr:::is_fig_path_ext(rmd[1]))
   expect_identical(
-    stringr::str_sub(workflowr:::create_figure_path(basename(rmd[1])), start = -4),
+    stringr::str_sub(workflowr:::create_figure_path(rmd[1]), start = -4),
     ".Rmd")
 
   # Publish a file with figures
@@ -79,8 +79,8 @@ test_that("fig_path_ext removes file extension in fig dir when set to FALSE", {
   # Figure functions detect that the setting is FALSE
   expect_true(workflowr:::is_fig_path_ext(rmd[1]))
   expect_identical(
-    basename(workflowr:::create_figure_path(basename(rmd[1]))),
-    tools::file_path_sans_ext(basename(rmd[1])))
+    basename(workflowr:::create_figure_path(rmd[1])),
+    basename(tools::file_path_sans_ext(rmd[1])))
 
   # Publish a file with figures
   file_w_figs <- file.path(s$analysis, "fig.Rmd")

--- a/tests/testthat/test-fig_path_ext.R
+++ b/tests/testthat/test-fig_path_ext.R
@@ -1,0 +1,103 @@
+context("fig_path_ext")
+
+# Scenario #1: explicitly set fig_path_ext to FALSE ----------------------------
+
+site_dir <- tempfile("test-fig_path_ext-")
+suppressMessages(wflow_start(site_dir, change_wd = FALSE, user.name = "Test Name",
+                             user.email = "test@email"))
+on.exit(unlink(site_dir, recursive = TRUE, force = TRUE))
+site_dir <- workflowr:::absolute(site_dir)
+
+s <- wflow_status(project = site_dir)
+
+rmd <- rownames(s$status)
+stopifnot(length(rmd) > 0)
+# Expected html files
+html <- workflowr:::to_html(rmd, outdir = s$docs)
+
+# Explicitly set fig_path_ext to FALSE
+cat("fig_path_ext: FALSE\n", file = file.path(s$root, "_workflowr.yml"),
+    append = TRUE)
+
+test_that("fig_path_ext has no effect when set to FALSE", {
+  # Confirm the setting is FALSE
+  wflow_yml <- file.path(s$root, "_workflowr.yml")
+  wflow_yml_opts <- yaml::yaml.load_file(wflow_yml)
+  expect_false(wflow_yml_opts$fig_path_ext)
+  wflow_opts <- workflowr:::wflow_options(rmd[1])
+  expect_false(wflow_opts$fig_path_ext)
+
+  # Figure functions detect that the setting is FALSE
+  expect_false(workflowr:::is_fig_path_ext(rmd[1]))
+  expect_identical(
+    stringr::str_sub(workflowr:::create_figure_path(basename(rmd[1])), start = -4),
+    ".Rmd")
+
+  # Publish a file with figures
+  file_w_figs <- file.path(s$analysis, "fig.Rmd")
+  file.copy("files/test-wflow_build/figure-v01.Rmd", file_w_figs)
+  published <- wflow_publish(file_w_figs, "A file with figures", view = FALSE,
+                             project = site_dir)
+  docs_fig <- file.path(s$docs, "figure", basename(file_w_figs), "unnamed-chunk-1-1.png")
+  expect_true(docs_fig %in% published$step3$commit_files)
+  analysis_fig <- file.path(s$analysis, "figure", basename(file_w_figs), "unnamed-chunk-1-1.png")
+  expect_false(file.exists(analysis_fig))
+
+  # Remove a file with figures
+  removed <- wflow_remove(file_w_figs, "Remove file", project = site_dir)
+  expect_true(docs_fig %in% removed$files_git)
+  expect_false(dir.exists(dirname(docs_fig)))
+})
+
+# Scenario #2: set fig_path_ext to TRUE ----------------------------------------
+
+site_dir <- tempfile("test-fig_path_ext-")
+suppressMessages(wflow_start(site_dir, change_wd = FALSE, user.name = "Test Name",
+                             user.email = "test@email"))
+on.exit(unlink(site_dir, recursive = TRUE, force = TRUE))
+site_dir <- workflowr:::absolute(site_dir)
+
+s <- wflow_status(project = site_dir)
+
+rmd <- rownames(s$status)
+stopifnot(length(rmd) > 0)
+# Expected html files
+html <- workflowr:::to_html(rmd, outdir = s$docs)
+
+# Set fig_path_ext to TRUE
+cat("fig_path_ext: TRUE\n", file = file.path(s$root, "_workflowr.yml"),
+    append = TRUE)
+
+test_that("fig_path_ext removes file extension in fig dir when set to FALSE", {
+  # Confirm the setting is TRUE
+  wflow_yml <- file.path(s$root, "_workflowr.yml")
+  wflow_yml_opts <- yaml::yaml.load_file(wflow_yml)
+  expect_true(wflow_yml_opts$fig_path_ext)
+  wflow_opts <- workflowr:::wflow_options(rmd[1])
+  expect_true(wflow_opts$fig_path_ext)
+
+  # Figure functions detect that the setting is FALSE
+  expect_true(workflowr:::is_fig_path_ext(rmd[1]))
+  expect_identical(
+    basename(workflowr:::create_figure_path(basename(rmd[1]))),
+    tools::file_path_sans_ext(basename(rmd[1])))
+
+  # Publish a file with figures
+  file_w_figs <- file.path(s$analysis, "fig.Rmd")
+  file.copy("files/test-wflow_build/figure-v01.Rmd", file_w_figs)
+  published <- wflow_publish(file_w_figs, "A file with figures", view = FALSE,
+                             project = site_dir)
+  docs_fig <- file.path(s$docs, "figure",
+                        tools::file_path_sans_ext(basename(file_w_figs)),
+                        "unnamed-chunk-1-1.png")
+  expect_true(docs_fig %in% published$step3$commit_files)
+  analysis_fig <- file.path(s$analysis, "figure",
+                            tools::file_path_sans_ext(basename(file_w_figs)),
+                            "unnamed-chunk-1-1.png")
+  expect_false(file.exists(analysis_fig))
+
+  # Remove a file with figures
+  removed <- wflow_remove(file_w_figs, "Remove file", project = site_dir)
+  expect_true(docs_fig %in% removed$files_git)
+  expect_false(dir.exists(dirname(docs_fig)))
+})


### PR DESCRIPTION
This PR adds support for removing the `.Rmd` extension in the figures paths, _via_ the `fig_path_ext` option as discussed in #119.

I took the liberty of adding two supporting functions in `wflow_options`. I'm open to any comments and modifications.