### PR TITLE
Avoid caching of automatic sessionInfo chunk

### DIFF
--- a/R/wflow_html.R
+++ b/R/wflow_html.R
@@ -279,7 +279,7 @@ wflow_html <- function(...) {
       sessioninfo <- c("",
                        "## Session information",
                        "",
-                       "```{r session-info-chunk-inserted-by-workflowr}",
+                       "```{r session-info-chunk-inserted-by-workflowr, cache = FALSE}",
                        wflow_opts$sessioninfo,
                        "```",
                        "")


### PR DESCRIPTION
Just noticed that if you have caching turned on the sessionInfo chunk is cached which probably isn't ideal. This cache just sets the chunk option so that doesn't happen. I realise there are problems with caching in general but think this shouldn't cause any more. Anyway up to you whether to merge.