### PR TITLE
Added error and test for overwrite = TRUE and existing = FALSE

### DIFF
--- a/R/wflow_start.R
+++ b/R/wflow_start.R
@@ -258,6 +258,9 @@ wflow_start <- function(directory,
   assert_is_flag(git)
   assert_is_flag(existing)
   assert_is_flag(overwrite)
+  if (overwrite && !existing) {
+    stop("Cannot overwrite non-existent project. Set existing = TRUE if you wish to overwrite existing workflowr files.")
+  }
   assert_is_flag(change_wd)
   assert_is_flag(disable_remote)
   assert_is_flag(dry_run)

--- a/tests/testthat/test-wflow_start.R
+++ b/tests/testthat/test-wflow_start.R
@@ -395,7 +395,7 @@ test_that("wflow_start fails if `overwrite = TRUE` and `existing = FALSE`", {
   site_dir <- workflowr:::absolute(site_dir)
   expect_error(wflow_start(site_dir, change_wd = FALSE, overwrite = TRUE,
                            user.name = "Test Name", user.email = "test@email"),
-               "Cannot overwrite non-existent project. Set existing = TRUE if you wish to overwrite existing workflowr files.")
+               "Cannot overwrite non-existent project.")
 
 })
 

--- a/tests/testthat/test-wflow_start.R
+++ b/tests/testthat/test-wflow_start.R
@@ -389,6 +389,16 @@ test_that("wflow_start changes to workflowr directory by default", {
   expect_identical(getwd(), site_dir)
 })
 
+test_that("wflow_start fails if `overwrite = TRUE` and `existing = FALSE`", {
+
+  site_dir <- tempfile("test-start-")
+  site_dir <- workflowr:::absolute(site_dir)
+  expect_error(wflow_start(site_dir, change_wd = FALSE, overwrite = TRUE,
+                           user.name = "Test Name", user.email = "test@email"),
+               "Cannot overwrite non-existent project. Set existing = TRUE if you wish to overwrite existing workflowr files.")
+
+})
+
 test_that("wflow_start fails early if directory exists and `existing = FALSE`", {
 
   site_dir <- tempfile("test-start-")


### PR DESCRIPTION
## Summary

To resolve issue #194, added error and test for when wflow_start() has overwrite = TRUE and existing = FALSE

## Checklist

- [X ] I agree to follow the [Code of Conduct][conduct]
- [X ] I have read the [contributing guidelines][contributing]
- [X ] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/jdblischak/workflowr/blob/master/CODE_OF_CONDUCT.md
[contributing]: https://github.com/jdblischak/workflowr/blob/master/CONTRIBUTING.md
[contribute.R]: https://github.com/jdblischak/workflowr/blob/master/scripts/contribute.R

## Details

