### PR TITLE
Unconditionally use `fs::path_real()`

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -75,11 +75,7 @@ absolute <- function(path) {
   # Ensure Windows Drive is uppercase
   newpath <- toupper_win_drive(newpath)
   # Resolve symlinks
-  if (.Platform$OS.type == "windows") {
-    newpath <- resolve_symlink(newpath)
-  } else {
-    newpath <- fs::path_real(newpath)
-  }
+  newpath <- resolve_symlink(newpath)
   newpath <- as.character(newpath)
 
   return(newpath)


### PR DESCRIPTION
In https://github.com/r-lib/fs/commit/2c3024f2a02510610f454f2e4dbf607a1a340ad2 I have reverted changes to `path_real()` which allowed it to work on file paths which did not actually exist on the file system.

Unfortunately while this feature can be useful, the implementation was too error prone and caused a number of additional issues, particularly on Windows. It also changes the mental model of what `path_real()` is supposed to do, how can you have a real path that doesn't actually exist.

This change broke workflowr, so this PR will fix the usage, using the workaround code you are already using.

I am sorry to break this, but this has been an ongoing issue and I think the previous behavior is easier to reason about.