### PR TITLE
Add combine parameter to wflow_build

### DIFF
--- a/R/wflow_build.R
+++ b/R/wflow_build.R
@@ -301,16 +301,14 @@ body(wflow_build_) <- quote({
   files_to_build <- files
   
   if(combine == "and"){
-    files_make <- return_modified_rmd(files_all, p$docs)
-    files_to_build <- intersect(files_to_build,files_make)
+    combine_files_function <- intersect
   }
-   if(combine == "or"){
-    files_make <- return_modified_rmd(files_all, p$docs)
-    files_to_build <- union(files_to_build,files_make)
+   else if(combine == "or"){
+     combine_files_function <- union
   }
   if (make) {
     files_make <- return_modified_rmd(files_all, p$docs)
-    files_to_build <- union(files_to_build, files_make)
+    files_to_build <- combine_files_function(files_to_build, files_make)
   }
 
   if (update || republish) {
@@ -319,13 +317,13 @@ body(wflow_build_) <- quote({
       files_update <- rownames(s$status)[s$status$mod_committed &
                                         !s$status$mod_unstaged &
                                         !s$status$mod_staged]
-      files_to_build <- union(files_to_build, files_update)
+      files_to_build <- combine_files_function(files_to_build, files_update)
     }
     if (republish) {
       files_republish <- rownames(s$status)[s$status$published &
                                            !s$status$mod_unstaged &
                                            !s$status$mod_staged]
-      files_to_build <- union(files_to_build, files_republish)
+      files_to_build <- combine_files_function(files_to_build, files_republish)
     }
   }
 

--- a/R/wflow_build.R
+++ b/R/wflow_build.R
@@ -297,7 +297,17 @@ body(wflow_build_) <- quote({
   # "and": Combine files with `intersect()`, i.e. only build files that are specified
   #   by all of the arguments.
 
+  #list of files
   files_to_build <- files
+  
+  if(combine == "and"){
+    files_make <- return_modified_rmd(files_all, p$docs)
+    files_to_build <- intersect(files_to_build,files_make)
+  }
+   if(combine == "or"){
+    files_make <- return_modified_rmd(files_all, p$docs)
+    files_to_build <- union(files_to_build,files_make)
+  }
   if (make) {
     files_make <- return_modified_rmd(files_all, p$docs)
     files_to_build <- union(files_to_build, files_make)


### PR DESCRIPTION
## Summary
Added combine parameter to wflow_build to specify how to combine Rmd files from the various arguments. The default of the combine argument is union. To use intersection to combine files, you would specify by passing **and** to the argument.

Example of using intersect to combine files:

```wflow_build("analysis/short*.Rmd", make = TRUE, combine = "and" )```

Example of using union to combine files:

1. You can do this by passing or into the combine argument
```wflow_build("analysis/short*.Rmd", make = TRUE, combine = "or" )```

2.You can not set the combine argument. The default for the combine argument is union
```wflow_build("analysis/short*.Rmd", make = TRUE)```


## Checklist

- [X] I agree to follow the [Code of Conduct][conduct]
- [X] I have read the [contributing guidelines][contributing]
- [X] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/jdblischak/workflowr/blob/master/CODE_OF_CONDUCT.md
[contributing]: https://github.com/jdblischak/workflowr/blob/master/CONTRIBUTING.md
[contribute.R]: https://github.com/jdblischak/workflowr/blob/master/scripts/contribute.R

## Details

