### PR TITLE
Add combine feature to wflow_publish

### DIFF
--- a/R/wflow_publish.R
+++ b/R/wflow_publish.R
@@ -177,14 +177,24 @@ wflow_publish <- function(
   files_to_build <- union(files_to_build,
                           step1$commit_files[
                             step1$commit_files %in% rownames(s1$status)])
+
+  #Check if the user wants an intersect build or union build of files
+
+  if(combine == "and"){
+    combine_files_function <- intersect
+  }
+   else if(combine == "or"){
+     combine_files_function <- union
+  }
+
   # If `republish == TRUE`, all published files
   if (republish) {
-    files_to_build <- union(files_to_build,
+    files_to_build <- combine_files_function(files_to_build,
                             rownames(s1$status)[s1$status$published])
   }
   # If `update == TRUE`, all published files with committed modifications
   if (update) {
-    files_to_build <- union(files_to_build,
+    files_to_build <- combine_files_function(files_to_build,
                             rownames(s1$status)[s1$status$mod_committed])
   }
   # None of these files can have unstaged/staged changes


### PR DESCRIPTION
## Summary
Added combine parameter feature that was recently added to wflow_build.R into wflow_publish. Now users can specify if they want to combine Rmd files in union or intersection.

## Checklist

- [X] I agree to follow the [Code of Conduct][conduct]
- [X] I have read the [contributing guidelines][contributing]
- [X] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/jdblischak/workflowr/blob/master/CODE_OF_CONDUCT.md
[contributing]: https://github.com/jdblischak/workflowr/blob/master/CONTRIBUTING.md
[contribute.R]: https://github.com/jdblischak/workflowr/blob/master/scripts/contribute.R

## Details

