### PR TITLE
Enable creation of toc for unpublished contents

### DIFF
--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -32,7 +32,7 @@
 #' @return Invisibly returns the table of contents as a character vector.
 #'
 #' @export
-wflow_toc <- function(ignore_nav_bar = TRUE, clipboard = TRUE, project = ".") {
+wflow_toc <- function(ignore_nav_bar = TRUE, clipboard = TRUE, only_published = TRUE, project = ".") {
 
   # Check input arguments ------------------------------------------------------
 
@@ -45,7 +45,16 @@ wflow_toc <- function(ignore_nav_bar = TRUE, clipboard = TRUE, project = ".") {
   # Create table of contents ---------------------------------------------------
 
   s <- wflow_status(project = project)
-  rmd <- rownames(s$status)[s$status$published]
+  if (only_published) {
+    rmd <- rownames(s$status)[s$status$published]
+    if (length(rmd)==0) {
+      warning("No suitable content to be added to the TOC found.
+If you wish to include unpublished contents, consider setting `only_published = FALSE`.")
+    }
+  } else {
+    rmd <- rownames(s$status)
+  }
+
   html <- to_html(basename(rmd))
 
   # Obtains the toc except the documents in the navigation bar.

--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -19,9 +19,6 @@
 #' \item Check that the system keyboard is writable. Run
 #' \code{\link[clipr]{clipr_available}} and \code{\link[clipr:clipr_available]{dr_clipr}}.
 #'
-#' \item If it's still not working, set \code{keyboard = FALSE} to send the
-#' table of contents to the R console to manually copy-paste.
-#'
 #' }
 #'
 #' @param ignore_nav_bar logical (default: TRUE). Ignore any HTML files included

--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -27,6 +27,7 @@
 #'   clipboard. Only relevant if
 #'   \href{https://cran.r-project.org/package=clipr}{clipr} package is installed
 #'   and the system keyboard is available.
+#' @param only_published logical (default: TRUE) Include only published contents.
 #' @inheritParams wflow_git_commit
 #'
 #' @return Invisibly returns the table of contents as a character vector.

--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -19,6 +19,9 @@
 #' \item Check that the system keyboard is writable. Run
 #' \code{\link[clipr]{clipr_available}} and \code{\link[clipr:clipr_available]{dr_clipr}}.
 #'
+#' \item If it's still not working, set \code{clipboard = FALSE} to send the
+#' table of contents to the R console to manually copy-paste.
+#'
 #' }
 #'
 #' @param ignore_nav_bar logical (default: TRUE). Ignore any HTML files included

--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -1,6 +1,6 @@
 #' Create table of contents
 #'
-#' \code{wfow_toc} creates a table of contents of the published R Markdown
+#' \code{wflow_toc} creates a table of contents of the published R Markdown
 #' files. The output is in markdown format, so you can paste it into a document
 #' such as \code{index.Rmd}. If the R package
 #' \href{https://cran.r-project.org/package=clipr}{clipr} is installed, the

--- a/R/wflow_toc.R
+++ b/R/wflow_toc.R
@@ -51,10 +51,6 @@ wflow_toc <- function(ignore_nav_bar = TRUE, clipboard = TRUE, only_published = 
   s <- wflow_status(project = project)
   if (only_published) {
     rmd <- rownames(s$status)[s$status$published]
-    if (length(rmd)==0) {
-      warning("No suitable content to be added to the TOC found.
-If you wish to include unpublished contents, consider setting `only_published = FALSE`.")
-    }
   } else {
     rmd <- rownames(s$status)
   }
@@ -69,6 +65,13 @@ If you wish to include unpublished contents, consider setting `only_published = 
 
     html <- html[!html_in_nav]
     rmd <- rmd[!html_in_nav]
+  }
+
+  if (length(rmd)==0) {
+    warning("No suitable content to be added to the TOC found.
+If you wish to include unpublished contents, consider setting `only_published = FALSE`.
+If you wish to include contents already linked in the navigation bar, consider setting `ignore_nav_bar = FALSE`.")
+    return(invisible(character()))
   }
 
   titles <- vapply(rmd, get_rmd_title, character(1))

--- a/man/wflow_toc.Rd
+++ b/man/wflow_toc.Rd
@@ -43,8 +43,5 @@ for you, you can try the following:
 \item Check that the system keyboard is writable. Run
 \code{\link[clipr]{clipr_available}} and \code{\link[clipr:clipr_available]{dr_clipr}}.
 
-\item If it's still not working, set \code{keyboard = FALSE} to send the
-table of contents to the R console to manually copy-paste.
-
 }
 }

--- a/man/wflow_toc.Rd
+++ b/man/wflow_toc.Rd
@@ -20,6 +20,8 @@ clipboard. Only relevant if
 \href{https://cran.r-project.org/package=clipr}{clipr} package is installed
 and the system keyboard is available.}
 
+\item{only_published}{logical (default: TRUE) Include only published contents.}
+
 \item{project}{character (default: ".") By default the function assumes the
 current working directory is within the project. If this is not true,
 you'll need to provide the path to the project directory.}

--- a/man/wflow_toc.Rd
+++ b/man/wflow_toc.Rd
@@ -4,7 +4,12 @@
 \alias{wflow_toc}
 \title{Create table of contents}
 \usage{
-wflow_toc(ignore_nav_bar = TRUE, clipboard = TRUE, project = ".")
+wflow_toc(
+  ignore_nav_bar = TRUE,
+  clipboard = TRUE,
+  only_published = TRUE,
+  project = "."
+)
 }
 \arguments{
 \item{ignore_nav_bar}{logical (default: TRUE). Ignore any HTML files included

--- a/man/wflow_toc.Rd
+++ b/man/wflow_toc.Rd
@@ -30,7 +30,7 @@ you'll need to provide the path to the project directory.}
 Invisibly returns the table of contents as a character vector.
 }
 \description{
-\code{wfow_toc} creates a table of contents of the published R Markdown
+\code{wflow_toc} creates a table of contents of the published R Markdown
 files. The output is in markdown format, so you can paste it into a document
 such as \code{index.Rmd}. If the R package
 \href{https://cran.r-project.org/package=clipr}{clipr} is installed, the

--- a/man/wflow_toc.Rd
+++ b/man/wflow_toc.Rd
@@ -50,5 +50,8 @@ for you, you can try the following:
 \item Check that the system keyboard is writable. Run
 \code{\link[clipr]{clipr_available}} and \code{\link[clipr:clipr_available]{dr_clipr}}.
 
+\item If it's still not working, set \code{clipboard = FALSE} to send the
+table of contents to the R console to manually copy-paste.
+
 }
 }


### PR DESCRIPTION
## Summary

This pull request includes the following changes:

- first, it removes references to a "keyboard" parameter in the documentation which is not any more present in the code
- second, it adds a warning message if the returned toc is empty. The warning (or message) could well be different, but I feel it would be useful to let the user know that the function is returning nothing (otherwise, one is left troubleshooting and wondering if there is something wrong with `clipr` or anything else)
- thirdly, it proposes a new parameter for enabling the creation of a toc of unpublished contents (defaults to FALSE). This can be useful in the drafting stage.
- finally, it fixes a small typo in the documentation

All edits are included in a single pull request, but are actually suggestions, as I suspect you would in any case likley want to adjust messages/documentation, even if you felt the proposed changes are pertinent.

## Checklist

- [ x] I agree to follow the [Code of Conduct][conduct]
- [ x] I have read the [contributing guidelines][contributing]
- [ x] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/jdblischak/workflowr/blob/master/CODE_OF_CONDUCT.md
[contributing]: https://github.com/jdblischak/workflowr/blob/master/CONTRIBUTING.md
[contribute.R]: https://github.com/jdblischak/workflowr/blob/master/scripts/contribute.R
