### PR TITLE
Use cat(sep = "\n") to avoid the accidental indentation

### DIFF
--- a/tests/testthat/test-wflow_run.R
+++ b/tests/testthat/test-wflow_run.R
@@ -43,10 +43,10 @@ test_that("wflow_run argument verbose controls code echoing", {
   withr::local_dir(path)
 
   rmd <- file.path(path, "analysis", "license.Rmd")
-  cat(c("```{r}\n",
-        "1 + 1\n",
-        "```\n"),
-      file = rmd, append = TRUE)
+  cat(c("```{r}",
+        "1 + 1",
+        "```"),
+      file = rmd, sep = "\n", append = TRUE)
 
   # default
   expect_output(wflow_run(rmd, project = path), "1 \\+ 1")


### PR DESCRIPTION
See https://github.com/yihui/knitr/issues/2057 and more details at https://yihui.org/en/2021/10/unbalanced-delimiters/.

## Summary

`cat()` adds a space before each line by default, which is unnecessary in this case of an R code chunk. We should really use the argument `sep = "\n"` instead of the default `sep = " "`.

## Checklist

- [x] I agree to follow the [Code of Conduct][conduct]
- [x] I have read the [contributing guidelines][contributing]
- [x] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/jdblischak/workflowr/blob/master/CODE_OF_CONDUCT.md
[contributing]: https://github.com/jdblischak/workflowr/blob/master/CONTRIBUTING.md
[contribute.R]: https://github.com/jdblischak/workflowr/blob/master/scripts/contribute.R

## Details

`cat()` generates

````
```{r}
 1 + 1
 ```
````

What we really need is

````
```{r}
1 + 1
```
````