### PR TITLE
Fix missing figure version table on Windows

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -234,9 +234,9 @@ view the files as they were in that past version.
 # Get versions table for figures. Needs to be refactored to share code with
 # get_versions.
 get_versions_fig <- function(fig, r, github) {
-  fig <- relative(fig, start = git2r::workdir(r))
-
   df_versions <- get_versions_df(fig, r)
+
+  fig <- relative(fig, start = git2r::workdir(r))
 
   # Exit early if there are no past versions
   if (length(df_versions) == 0) {


### PR DESCRIPTION
## Summary

* Fix missing figure version table on Windows by passing absolute path to get_versions_df() function
* Add simple test to verify that figure version table appears in output html (only verifying button text)

## Checklist

- [x] I agree to follow the [Code of Conduct][conduct]
- [x] I have read the [contributing guidelines][contributing]
- [x] I ran the script [scripts/contribute.R][contribute.R]

[conduct]: https://github.com/workflowr/workflowr/blob/main/CODE_OF_CONDUCT.md
[contributing]: https://github.com/workflowr/workflowr/blob/main/CONTRIBUTING.md
[contribute.R]: https://github.com/workflowr/workflowr/blob/main/scripts/contribute.R

## Details

Figure version table is not showing when building on Windows due to an upstream bug with `git2r::commits` function and relative paths on Windows (https://github.com/ropensci/git2r/issues/394). This pull request addresses this issue by passing full path to the corresponding functions. A rudimentary test is also added to verify that the button (which expands the figure version table) appears on the output html file.
